### PR TITLE
Feature/kas 2777 agenda performance

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import { AUTO_RUN, BACKEND_URL,
          ENABLE_RECENT_AGENDAS_CACHE, ENABLE_LARGE_AGENDAS_CACHE,
          MIN_NB_OF_AGENDAITEMS, MU_AUTH_ALLOWED_GROUPS } from './config';
-import { fetchMostRecentAgendas, fetchLargeAgendas } from './helpers';
+import * as helpers from './helpers';
 
 app.get('/', function(req, res) {
   res.send("Are you cold? Let's warm this place up.");
@@ -19,7 +19,7 @@ if (AUTO_RUN)
 
 async function warmup() {
   if (ENABLE_RECENT_AGENDAS_CACHE) {
-    const agendaIds = await fetchMostRecentAgendas();
+    const agendaIds = await helpers.fetchMostRecentAgendas();
     console.log(`Found ${agendaIds.length} agendas that have been modified last year`);
     await warmupAgendas(agendaIds);
   } else {
@@ -27,7 +27,7 @@ async function warmup() {
   }
 
   if (ENABLE_LARGE_AGENDAS_CACHE) {
-    const agendaIds = await fetchLargeAgendas();
+    const agendaIds = await helpers.fetchLargeAgendas();
     console.log(`Found ${agendaIds.length} agendas that have more than ${MIN_NB_OF_AGENDAITEMS} agendaitems`);
     await warmupAgendas(agendaIds);
   } else {
@@ -52,27 +52,50 @@ async function warmupAgendas(agendas) {
 }
 
 async function warmupAgenda(agenda, allowedGroupHeader) {
-  const url = getAgendaitemsRequestUrl(agenda);
-  await fetch(url, {
-    method: 'GET',
-    headers: {
-      'mu-auth-allowed-groups': allowedGroupHeader
-    }
-  });
+  const urls = await getAgendaitemsRequestUrls(agenda);
+  for (let url of urls) {
+    await fetch(url, {
+      method: 'GET',
+      headers: {
+        'mu-auth-allowed-groups': allowedGroupHeader
+      }
+    });
+  }
 }
 
-function getAgendaitemsRequestUrl(agendaId) {
+async function getAgendaitemsRequestUrls(agendaId) {
+  const agendaitemIds = await helpers.fetchAgendaitemsFromAgenda(agendaId);
+  const urls = [];
+  // agendaitems of the agenda
   const path = 'agendaitems';
   const params = new URLSearchParams({
-    'fields[document-containers]': '',
-    'fields[mandatees]': 'title,priority',
-    'fields[pieces]': 'name,document-container,created,confidential',
     'filter[agenda][:id:]': agendaId,
-    'include': 'mandatees,pieces,pieces.document-container',
     'page[size]': 300,
     'sort': 'show-as-remark,number'
   });
-  return `${BACKEND_URL}${path}?${params}`;
+  urls.push(`${BACKEND_URL}${path}?${params}`);
+
+  // agendaitem mandatees
+  for (let agendaitemId of agendaitemIds) {
+    const path = `agendaitems/${agendaitemId}`;
+    const params = new URLSearchParams({
+      'include': 'mandatees',
+    });
+    urls.push(`${BACKEND_URL}${path}?${params}`);
+  }
+
+  // agendaitem pieces
+  for (let agendaitemId of agendaitemIds) {
+    const path = 'pieces';
+    const params = new URLSearchParams({
+      'filter[agendaitems][:id:]': agendaitemId,
+      'include': 'document-container',
+      'page[size]': 500,
+    });
+    urls.push(`${BACKEND_URL}${path}?${params}`);
+  }
+
+  return urls;
 }
 
 app.use(errorHandler);

--- a/app.js
+++ b/app.js
@@ -1,37 +1,49 @@
-import { app, errorHandler } from 'mu';
-import fetch from 'node-fetch';
-import { AUTO_RUN, BACKEND_URL,
-         ENABLE_RECENT_AGENDAS_CACHE, ENABLE_LARGE_AGENDAS_CACHE,
-         MIN_NB_OF_AGENDAITEMS, MU_AUTH_ALLOWED_GROUPS } from './config';
-import * as helpers from './helpers';
+import { app, errorHandler } from "mu";
+import fetch from "node-fetch";
+import {
+  AUTO_RUN,
+  BACKEND_URL,
+  ENABLE_RECENT_AGENDAS_CACHE,
+  ENABLE_LARGE_AGENDAS_CACHE,
+  MIN_NB_OF_AGENDAITEMS,
+  MU_AUTH_ALLOWED_GROUPS,
+} from "./config";
+import * as helpers from "./helpers";
 
-app.get('/', function(req, res) {
+app.get("/", function (req, res) {
   res.send("Are you cold? Let's warm this place up.");
 });
 
-app.post('/warmup', function(req, res) {
+app.post("/warmup", function (req, res) {
   warmup();
   res.status(202).send();
 });
 
-if (AUTO_RUN)
-  warmup();
+if (AUTO_RUN) warmup();
 
 async function warmup() {
   if (ENABLE_RECENT_AGENDAS_CACHE) {
     const agendaIds = await helpers.fetchMostRecentAgendas();
-    console.log(`Found ${agendaIds.length} agendas that have been modified last year`);
+    console.log(
+      `Found ${agendaIds.length} agendas that have been modified last year`
+    );
     await warmupAgendas(agendaIds);
   } else {
-    console.log(`Caching of recent agendas disabled. Set ENABLE_RECENT_AGENDAS_CACHE env var on "true" to enable.`);
+    console.log(
+      `Caching of recent agendas disabled. Set ENABLE_RECENT_AGENDAS_CACHE env var on "true" to enable.`
+    );
   }
 
   if (ENABLE_LARGE_AGENDAS_CACHE) {
     const agendaIds = await helpers.fetchLargeAgendas();
-    console.log(`Found ${agendaIds.length} agendas that have more than ${MIN_NB_OF_AGENDAITEMS} agendaitems`);
+    console.log(
+      `Found ${agendaIds.length} agendas that have more than ${MIN_NB_OF_AGENDAITEMS} agendaitems`
+    );
     await warmupAgendas(agendaIds);
   } else {
-    console.log(`Caching of large agendas disabled. Set ENABLE_LARGE_AGENDAS_CACHE env var on "true" to enable.`);
+    console.log(
+      `Caching of large agendas disabled. Set ENABLE_LARGE_AGENDAS_CACHE env var on "true" to enable.`
+    );
   }
 }
 
@@ -44,10 +56,11 @@ async function warmupAgendas(agendas) {
     for (let agenda of agendas) {
       i++;
       await warmupAgenda(agenda, allowedGroupHeader);
-      if (i % 10 == 0)
-        console.log(`Loaded ${i} agendas in cache`);
+      if (i % 10 == 0) console.log(`Loaded ${i} agendas in cache`);
     }
-    console.log(`Finished warming up cache for allowed group ${allowedGroupHeader}`);
+    console.log(
+      `Finished warming up cache for allowed group ${allowedGroupHeader}`
+    );
   }
 }
 
@@ -55,10 +68,10 @@ async function warmupAgenda(agenda, allowedGroupHeader) {
   const urls = await getAgendaitemsRequestUrls(agenda);
   for (let url of urls) {
     await fetch(url, {
-      method: 'GET',
+      method: "GET",
       headers: {
-        'mu-auth-allowed-groups': allowedGroupHeader
-      }
+        "mu-auth-allowed-groups": allowedGroupHeader,
+      },
     });
   }
 }
@@ -67,11 +80,11 @@ async function getAgendaitemsRequestUrls(agendaId) {
   const agendaitemIds = await helpers.fetchAgendaitemsFromAgenda(agendaId);
   const urls = [];
   // agendaitems of the agenda
-  const path = 'agendaitems';
+  const path = "agendaitems";
   const params = new URLSearchParams({
-    'filter[agenda][:id:]': agendaId,
-    'page[size]': 300,
-    'sort': 'show-as-remark,number'
+    "filter[agenda][:id:]": agendaId,
+    "page[size]": 300,
+    sort: "show-as-remark,number",
   });
   urls.push(`${BACKEND_URL}${path}?${params}`);
 
@@ -79,18 +92,18 @@ async function getAgendaitemsRequestUrls(agendaId) {
   for (let agendaitemId of agendaitemIds) {
     const path = `agendaitems/${agendaitemId}`;
     const params = new URLSearchParams({
-      'include': 'mandatees',
+      include: "mandatees",
     });
     urls.push(`${BACKEND_URL}${path}?${params}`);
   }
 
   // agendaitem pieces
   for (let agendaitemId of agendaitemIds) {
-    const path = 'pieces';
+    const path = "pieces";
     const params = new URLSearchParams({
-      'filter[agendaitems][:id:]': agendaitemId,
-      'include': 'document-container',
-      'page[size]': 500,
+      "filter[agendaitems][:id:]": agendaitemId,
+      include: "document-container",
+      "page[size]": 500,
     });
     urls.push(`${BACKEND_URL}${path}?${params}`);
   }

--- a/helpers.js
+++ b/helpers.js
@@ -1,4 +1,4 @@
-import { sparqlEscapeDateTime } from 'mu';
+import { sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
 import { querySudo as query } from '@lblod/mu-auth-sudo';
 import { MASTER_GRAPH, MIN_NB_OF_AGENDAITEMS } from './config';
 
@@ -44,7 +44,27 @@ async function fetchLargeAgendas() {
   return queryResult.results.bindings.map(b => b['agendaId'].value);
 }
 
+async function fetchAgendaitemsFromAgenda(agendaId) {
+  const queryResult = await query(`
+    PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    SELECT DISTINCT ?agendaitemId {
+      GRAPH <${MASTER_GRAPH}> {
+        ?agenda a besluitvorming:Agenda ;
+          mu:uuid ${sparqlEscapeString(agendaId)};
+          dct:hasPart ?agendaitem .
+        ?agendaitem mu:uuid ?agendaitemId .
+      }
+    }
+    `);
+  return queryResult.results.bindings.map((binding) => {
+    return binding.agendaitemId.value;
+  });
+}
+
 export {
   fetchMostRecentAgendas,
-  fetchLargeAgendas
+  fetchLargeAgendas,
+  fetchAgendaitemsFromAgenda
 }

--- a/helpers.js
+++ b/helpers.js
@@ -1,6 +1,6 @@
-import { sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
-import { querySudo as query } from '@lblod/mu-auth-sudo';
-import { MASTER_GRAPH, MIN_NB_OF_AGENDAITEMS } from './config';
+import { sparqlEscapeDateTime, sparqlEscapeString } from "mu";
+import { querySudo as query } from "@lblod/mu-auth-sudo";
+import { MASTER_GRAPH, MIN_NB_OF_AGENDAITEMS } from "./config";
 
 async function fetchMostRecentAgendas() {
   const since = new Date();
@@ -19,7 +19,7 @@ async function fetchMostRecentAgendas() {
     } ORDER BY DESC(?modified)
   `);
 
-  return queryResult.results.bindings.map(b => b['agendaId'].value);
+  return queryResult.results.bindings.map((b) => b["agendaId"].value);
 }
 
 async function fetchLargeAgendas() {
@@ -41,7 +41,7 @@ async function fetchLargeAgendas() {
       }
       FILTER (?count > ${MIN_NB_OF_AGENDAITEMS})
     } ORDER BY DESC(?count)`);
-  return queryResult.results.bindings.map(b => b['agendaId'].value);
+  return queryResult.results.bindings.map((b) => b["agendaId"].value);
 }
 
 async function fetchAgendaitemsFromAgenda(agendaId) {
@@ -66,5 +66,5 @@ async function fetchAgendaitemsFromAgenda(agendaId) {
 export {
   fetchMostRecentAgendas,
   fetchLargeAgendas,
-  fetchAgendaitemsFromAgenda
-}
+  fetchAgendaitemsFromAgenda,
+};


### PR DESCRIPTION
ticket: https://kanselarij.atlassian.net/browse/KAS-2777

Split up the large query to get all agendaitems of 1 agenda with all mandatee and piece data to separate calls that are also used in frontend https://github.com/kanselarij-vlaanderen/kaleidos-frontend/pull/1113

- added a helper method to get all agendaitems from 1 agenda.
- replaced the current method to get data with a method that gets all agendaitems first, then for each agendaitem get the mandatee data and piece data in seperate urls.
- all those urls are sent back in a list and executed 1 by 1.
- ran the prettier formatter on both the "touched" files


comments: 
- The loading of most recent agendas and large agendas may end up loading the same agendas twice, although the second time the calls are almost instant because they are already cached.
Perhaps we can keep a local list with agendaIds that are done to check against?
- On ACC data, the warmup takes 6 hours pre refactor, can we speed this process up by running multiple cache calls in parallel ?
- The formatter changed all single quotes to double quotes, not sure if this is desirable (it is a default of the formatter to have double quotes)
