### PR TITLE
Feature/kas 3019 warmup better

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,17 +80,21 @@ async function warmupAgenda(agenda, allowedGroupHeader) {
   try {
     await Promise.all(
       urls.map(async (url) => {
-        fetch(url, {
+        return fetch(url, {
           method: "GET",
           headers: {
             "mu-auth-allowed-groups": allowedGroupHeader,
           },
+        }).catch((error) => {
+          throw error;
         });
       })
-    );
+    ).catch((error) => {
+      throw error;
+    });
   } catch (error) {
     console.warn(`error warming up agenda ${agenda}, not retrying`);
-    console.error(error);
+    console.error(error.message);
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -41,7 +41,7 @@ async function warmup() {
     console.log(
       `Found ${largeAgendaIds.length} agendas that have more than ${MIN_NB_OF_AGENDAITEMS} agendaitems`
     );
-    if (cachedAgendaIds.length > 1) {
+    if (cachedAgendaIds.length) {
       let filteredAgendaIds = largeAgendaIds.filter(
         (agendaId) => !cachedAgendaIds.includes(agendaId)
       );

--- a/app.js
+++ b/app.js
@@ -78,20 +78,15 @@ async function warmupAgendas(agendas) {
 async function warmupAgenda(agenda, allowedGroupHeader) {
   const urls = await getAgendaitemsRequestUrls(agenda);
   try {
-    await Promise.all(
-      urls.map(async (url) => {
-        return fetch(url, {
-          method: "GET",
-          headers: {
-            "mu-auth-allowed-groups": allowedGroupHeader,
-          },
-        }).catch((error) => {
-          throw error;
-        });
-      })
-    ).catch((error) => {
-      throw error;
-    });
+    const promises = urls.map((url) => {
+      return fetch(url, {
+        method: "GET",
+        headers: {
+          "mu-auth-allowed-groups": allowedGroupHeader,
+        }
+      });
+    })
+    await Promise.all(promises);
   } catch (error) {
     console.warn(`error warming up agenda ${agenda}, not retrying`);
     console.error(error.message);

--- a/app.js
+++ b/app.js
@@ -22,12 +22,14 @@ app.post("/warmup", function (req, res) {
 if (AUTO_RUN) warmup();
 
 async function warmup() {
+  let cachedAgendaIds = [];
   if (ENABLE_RECENT_AGENDAS_CACHE) {
-    const agendaIds = await helpers.fetchMostRecentAgendas();
+    const recentAgendaIds = await helpers.fetchMostRecentAgendas();
     console.log(
-      `Found ${agendaIds.length} agendas that have been modified last year`
+      `Found ${recentAgendaIds.length} agendas that have been modified last year`
     );
-    await warmupAgendas(agendaIds);
+    await warmupAgendas(recentAgendaIds);
+    cachedAgendaIds = recentAgendaIds;
   } else {
     console.log(
       `Caching of recent agendas disabled. Set ENABLE_RECENT_AGENDAS_CACHE env var on "true" to enable.`
@@ -35,11 +37,20 @@ async function warmup() {
   }
 
   if (ENABLE_LARGE_AGENDAS_CACHE) {
-    const agendaIds = await helpers.fetchLargeAgendas();
+    let largeAgendaIds = await helpers.fetchLargeAgendas();
     console.log(
-      `Found ${agendaIds.length} agendas that have more than ${MIN_NB_OF_AGENDAITEMS} agendaitems`
+      `Found ${largeAgendaIds.length} agendas that have more than ${MIN_NB_OF_AGENDAITEMS} agendaitems`
     );
-    await warmupAgendas(agendaIds);
+    if (cachedAgendaIds.length > 1) {
+      let filteredAgendaIds = largeAgendaIds.filter(
+        (agendaId) => !cachedAgendaIds.includes(agendaId)
+      );
+      console.log(
+        `Of those ${largeAgendaIds.length} agendas, ${filteredAgendaIds.length} agendas have not yet been cached.`
+      );
+      largeAgendaIds = filteredAgendaIds;
+    }
+    await warmupAgendas(largeAgendaIds);
   } else {
     console.log(
       `Caching of large agendas disabled. Set ENABLE_LARGE_AGENDAS_CACHE env var on "true" to enable.`
@@ -66,13 +77,20 @@ async function warmupAgendas(agendas) {
 
 async function warmupAgenda(agenda, allowedGroupHeader) {
   const urls = await getAgendaitemsRequestUrls(agenda);
-  for (let url of urls) {
-    await fetch(url, {
-      method: "GET",
-      headers: {
-        "mu-auth-allowed-groups": allowedGroupHeader,
-      },
-    });
+  try {
+    await Promise.all(
+      urls.map(async (url) => {
+        fetch(url, {
+          method: "GET",
+          headers: {
+            "mu-auth-allowed-groups": allowedGroupHeader,
+          },
+        });
+      })
+    );
+  } catch (error) {
+    console.warn(`error warming up agenda ${agenda}, not retrying`);
+    console.error(error);
   }
 }
 


### PR DESCRIPTION
- More error catching
- Don't cache the same agenda twice
- fetch in parallel


instead of throwing an error and the service just stopping, we now just log it.
![image](https://user-images.githubusercontent.com/22245223/151004609-64297b0e-be53-40fe-b8a8-734ca89a45de.png)
We could retry or add the agendaId to a list for later processing, but wanted to avoid getting stuck in an endless loop.
Best to check the logs for errors and restart the service later.