### PR TITLE
Feature/kas 3428 cache warmup minder agressief maken voor database

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following settings can be configured through environment variables:
 - **ENABLE_RECENT_AGENDAS_CACHE**: runs the warmup process for agendas modified during the last year if set to `"true"` (default `"true"`)
 - **ENABLE_LARGE_AGENDAS_CACHE**: runs the warmup process for large agendas if set to `"true"` (default `"true"`)
 - **MIN_NB_OF_AGENDAITEMS**: minimum number of agendaitems for an agenda to be considered 'large' (default `"70"`)
+- **REQUEST_CHUNK_SIZE**: the max number of requests that will be made in parallel (default `10`)
 
 ### Endpoints
 #### POST /warmup

--- a/app.js
+++ b/app.js
@@ -60,19 +60,17 @@ async function warmup() {
 }
 
 async function warmupAgendas(agendas) {
-  for (let group of MU_AUTH_ALLOWED_GROUPS) {
-    const allowedGroupHeader = JSON.stringify(group);
-    console.log(`Warming up cache for allowed group ${allowedGroupHeader}`);
+  let i = 0;
+  for (let agenda of agendas) {
+    console.log(`Warming up cache for all allowed groups for agenda ${agenda}`);
 
-    let i = 0;
-    for (let agenda of agendas) {
-      i++;
+    for (let group of MU_AUTH_ALLOWED_GROUPS) {
+      const allowedGroupHeader = JSON.stringify(group);
       await warmupAgenda(agenda, allowedGroupHeader);
-      if (i % 10 == 0) console.log(`Loaded ${i} agendas in cache`);
     }
-    console.log(
-      `Finished warming up cache for allowed group ${allowedGroupHeader}`
-    );
+
+    i++;
+    if (i % 10 == 0) console.log(`Loaded ${i} agendas in cache`);
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ import {
   ENABLE_LARGE_AGENDAS_CACHE,
   MIN_NB_OF_AGENDAITEMS,
   MU_AUTH_ALLOWED_GROUPS,
+  REQUEST_CHUNK_SIZE,
 } from "./config";
 import * as helpers from "./helpers";
 
@@ -77,10 +78,9 @@ async function warmupAgendas(agendas) {
 
 async function warmupAgenda(agenda, allowedGroupHeader) {
   const urls = await getAgendaitemsRequestUrls(agenda);
-  const chunkSize = 10;
-  const chunkedUrls = helpers.chunk(urls, chunkSize);
+  const chunkedUrls = helpers.chunk(urls, REQUEST_CHUNK_SIZE);
   console.log(
-    `Warming up agenda ${agenda} requires ${urls.length} requests which will be made in parallel in batches of ${chunkSize}`
+    `Warming up agenda ${agenda} requires ${urls.length} requests which will be made in parallel in batches of ${REQUEST_CHUNK_SIZE}`
   )
   try {
     for (const chunk of chunkedUrls) {

--- a/app.js
+++ b/app.js
@@ -77,16 +77,23 @@ async function warmupAgendas(agendas) {
 
 async function warmupAgenda(agenda, allowedGroupHeader) {
   const urls = await getAgendaitemsRequestUrls(agenda);
+  const chunkSize = 10;
+  const chunkedUrls = helpers.chunk(urls, chunkSize);
+  console.log(
+    `Warming up agenda ${agenda} requires ${urls.length} requests which will be made in parallel in batches of ${chunkSize}`
+  )
   try {
-    const promises = urls.map((url) => {
-      return fetch(url, {
-        method: "GET",
-        headers: {
-          "mu-auth-allowed-groups": allowedGroupHeader,
-        }
+    for (const chunk of chunkedUrls) {
+      const promises = chunk.map((url) => {
+        return fetch(url, {
+          method: "GET",
+          headers: {
+            "mu-auth-allowed-groups": allowedGroupHeader,
+          }
+        });
       });
-    });
-    await Promise.all(promises);
+      await Promise.all(promises);
+    }
   } catch (error) {
     console.warn(`error warming up agenda ${agenda}, not retrying`);
     console.error(error.message);

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 const BACKEND_URL = process.env.BACKEND_URL || 'http://cache/';
 const MASTER_GRAPH = process.env.MASTER_GRAPH || 'http://mu.semte.ch/graphs/organizations/kanselarij';
 const AUTO_RUN = ["yes", "true", true, "1", 1, "on"].includes(process.env.AUTO_RUN);
+const REQUEST_CHUNK_SIZE = parseInt(process.env.REQUEST_CHUNK_SIZE) || 10;
 const ENABLE_RECENT_AGENDAS_CACHE = ["yes", "true", true, "1", 1, "on"].includes(process.env.ENABLE_RECENT_AGENDAS_CACHE);
 const ENABLE_LARGE_AGENDAS_CACHE = ["yes", "true", true, "1", 1, "on"].includes(process.env.ENABLE_LARGE_AGENDAS_CACHE);
 const MIN_NB_OF_AGENDAITEMS = Number.parseInt(process.env.MIN_NB_OF_AGENDAITEMS || "70");
@@ -48,5 +49,6 @@ export {
   ENABLE_RECENT_AGENDAS_CACHE,
   ENABLE_LARGE_AGENDAS_CACHE,
   MIN_NB_OF_AGENDAITEMS,
-  MU_AUTH_ALLOWED_GROUPS
+  MU_AUTH_ALLOWED_GROUPS,
+  REQUEST_CHUNK_SIZE,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -63,8 +63,16 @@ async function fetchAgendaitemsFromAgenda(agendaId) {
   });
 }
 
+function chunk(array, size) {
+  let chunked = [];
+  for (let i = 0; i < array.length; i += size)
+    chunked.push(array.slice(i, i + size));
+  return chunked;
+};
+
 export {
   fetchMostRecentAgendas,
   fetchLargeAgendas,
   fetchAgendaitemsFromAgenda,
+  chunk,
 };


### PR DESCRIPTION
Requests are now batched (by default in batches of 10 requests) to the backend to prevent overloading it (previously, we would regularly send >200 requests per agenda).

Additionally, groups are now cached per agenda, instead of agendas being cached per group. I.e. an agenda will cached for all the groups before moving on to the following agenda. This should make the caching more noticeable to users.

Using ACC data, I couldn't reproduce warnings locally, perhaps because as a single user the system wasn't as overloaded as it would be in production, but a very noticeable slow down was present. After these changes the slow down is diminished (as well as the sustained system load), which should hopefully translate to better usability in production.