### PR TITLE
KAS-2711: Use agendaitem type instead of show-as-remark

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,7 +111,7 @@ async function getAgendaitemsRequestUrls(agendaId) {
   const params = new URLSearchParams({
     "filter[agenda][:id:]": agendaId,
     "page[size]": 300,
-    sort: "show-as-remark,number",
+    sort: "type,number",
   });
   urls.push(`${BACKEND_URL}${path}?${params}`);
 


### PR DESCRIPTION
One of the cached calls was using `show-as-remark`, which has been replaced with `type`.