### PR TITLE
Feature/kas 4433 send to vp role permissions

### DIFF
--- a/config.js
+++ b/config.js
@@ -20,6 +20,8 @@ const MU_AUTH_ALLOWED_GROUPS = [
     { "variables": [], "name": "ovrb-write" },
     { "variables": [], "name": "sign-flow-read" },
     { "variables": [], "name": "sign-flow-write" },
+    { "variables": [], "name": "parliament-flow-read" },
+    { "variables": [], "name": "parliament-flow-write" },
     { "variables": [], "name": "clean" }
   ],
   [ // Secretarie / KB
@@ -29,6 +31,8 @@ const MU_AUTH_ALLOWED_GROUPS = [
     { "variables": [], "name": "kanselarij-write" },
     { "variables": [], "name": "sign-flow-read" },
     { "variables": [], "name": "sign-flow-write" },
+    { "variables": [], "name": "parliament-flow-read" },
+    { "variables": [], "name": "parliament-flow-write" },
     { "variables": [], "name": "clean" }
   ],
   [ // OVRB
@@ -37,6 +41,7 @@ const MU_AUTH_ALLOWED_GROUPS = [
     { "variables": [], "name": "kanselarij-read" },
     { "variables": [], "name": "ovrb-write" },
     { "variables": [], "name": "sign-flow-read" },
+    { "variables": [], "name": "parliament-flow-read" },
     { "variables": [], "name": "clean" }
   ],
   [ // Minister
@@ -46,6 +51,8 @@ const MU_AUTH_ALLOWED_GROUPS = [
     { "variables": [], "name": "minister-write" },
     { "variables": [], "name": "sign-flow-read" },
     { "variables": [], "name": "sign-flow-write" },
+    { "variables": [], "name": "parliament-flow-write" },
+    { "variables": [], "name": "parliament-flow-read" },
     { "variables": [], "name": "clean" }
   ],
   [ // Regering / kabinet
@@ -54,6 +61,7 @@ const MU_AUTH_ALLOWED_GROUPS = [
     { "variables": [], "name": "regering-read" },
     { "variables": [], "name": "regering-write" },
     { "variables": [], "name": "sign-flow-read" },
+    { "variables": [], "name": "parliament-flow-read" },
     { "variables": [], "name": "clean" }
   ],
   [ // Overheid
@@ -61,6 +69,7 @@ const MU_AUTH_ALLOWED_GROUPS = [
     { "variables": [], "name": "authenticated" },
     { "variables": [], "name": "overheid-read" },
     { "variables": [], "name": "overheid-write" },
+    { "variables": [], "name": "parliament-flow-read" },
     { "variables": [], "name": "clean" }
   ]
 ];

--- a/config.js
+++ b/config.js
@@ -32,7 +32,6 @@ const MU_AUTH_ALLOWED_GROUPS = [
     { "variables": [], "name": "sign-flow-read" },
     { "variables": [], "name": "sign-flow-write" },
     { "variables": [], "name": "parliament-flow-read" },
-    { "variables": [], "name": "parliament-flow-write" },
     { "variables": [], "name": "clean" }
   ],
   [ // OVRB
@@ -44,7 +43,7 @@ const MU_AUTH_ALLOWED_GROUPS = [
     { "variables": [], "name": "parliament-flow-read" },
     { "variables": [], "name": "clean" }
   ],
-  [ // Minister
+  [ // Minister, kabinetchef & kabinetdossierbeheerder
     { "variables": [], "name": "public" },
     { "variables": [], "name": "authenticated" },
     { "variables": [], "name": "minister-read" },


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4433

Adds the new `parliament-flow-{read,write}` allowed groups to the warmup.